### PR TITLE
Prepare run test script for Superbol CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ libgixpp/location.hh
 
 # Others
 _install
+_output
 packages
 deploy/redist
 **/Win32

--- a/gixsql-tests-nunit/CompilerConfig2.cs
+++ b/gixsql-tests-nunit/CompilerConfig2.cs
@@ -30,6 +30,8 @@ namespace gixsql_tests
             bool isWindows = !File.Exists(@"/proc/sys/kernel/ostype");
             bool isLegacyPreprocessor =
               Environment.GetEnvironmentVariable("LEGACY_PP") != null;
+            string superbolPreprocessor =
+              Environment.GetEnvironmentVariable("SUPERBOL_PP");
 
             try
             {
@@ -92,7 +94,7 @@ namespace gixsql_tests
                     }
                     else
                     {
-                      cc.gixpp_exe = "/opt/superbol-free-linux-x64";
+                      cc.gixpp_exe = superbolPreprocessor;
                     }
 
                     if (!File.Exists(cc.gixpp_exe)) throw new Exception(cc.gixpp_exe);

--- a/run_test.sh
+++ b/run_test.sh
@@ -4,20 +4,46 @@ set -o nounset
 set -o pipefail
 
 # Default configuration
-INSTALL_DIR=${INSTALL_DIR:=_install}
+INSTALL_DIR="$PWD/_install"
+OUTPUT_DIR="$PWD/_output"
 
-POSTGRE_HOST=${POSTGRE_HOST:=localhost}
-POSTGRE_PORT=${POSTGRE_PORT:=5432}
-POSTGRE_USER=${POSTGRE_USER:=test}
-POSTGRE_PWD=${POSTGRE_PWD:=test}
-POSTGRE_DB1=${POSTGRE_DB1:=testdb1}
-POSTGRE_DB2=${POSTGRE_DB2:=testdb2}
+# These parameters are exported for PostgreSQL tools
+export PGHOST=${POSTGRE_HOST:=localhost}
+export PGPORT=${POSTGRE_PORT:=5432}
+export PGUSER=${POSTGRE_USER:=test}
+export PGPASSWORD=${PGPASSWORD:=test}
 
+PGDB1=${POSTGRE_DB1:=testdb1}
+PGDB2=${POSTGRE_DB2:=testdb2}
 TEST_VERBOSITY=${TEST_VERBOSITY:=0}
-TEST_DIR=${TEST_DIR:=/tmp/gixsql-test}
-export GIXTEST_LOCAL_CONFIG="$TEST_DIR/config.xml"
+
+# These parameters are exported for the test runner
+export GIXTEST_LOCAL_CONFIG="$OUTPUT_DIR/config.xml"
 
 INSTALL_PATH="$PWD/$INSTALL_DIR"
+PG_DIR="$OUTPUT_DIR/pg"
+
+if [ -d "$OUTPUT_DIR" ]; then
+  pg_ctl -D "$PG_DIR" stop || true
+  rm -rf "$OUTPUT_DIR"
+fi
+mkdir "$OUTPUT_DIR"
+
+# Configure and start PostgreSQL
+echo "test" >> "$OUTPUT_DIR/pg_password"
+initdb -U "$PGUSER" -D "$PG_DIR" \
+  --pwfile="$OUTPUT_DIR/pg_password"
+
+cat <<EOF >> "$PG_DIR/postgresql.conf"
+listen_addresses = '$PGHOST'
+unix_socket_directories = '.'
+port = $PGPORT
+EOF
+
+pg_ctl -D "$PG_DIR" -l "$OUTPUT_DIR/pg.log" start
+createdb $PGDB1
+createdb $PGDB2
+pg_ctl -D "$PG_DIR" status
 
 # Build and locally install the project
 if [ ! -f "./extra_files.mk" ]; then
@@ -32,26 +58,15 @@ if [ ! -d "$INSTALL_DIR" ]; then
 fi
 
 autoreconf -if
-./configure --prefix="$INSTALL_PATH"
+./configure --prefix="$INSTALL_PATH" --disable-mysql \
+  --disable-odbc --disable-sqlite --disable-oracle
 make -j 8
 make install
 
 echo "Preparing tests..."
-if [ -d "$TEST_DIR" ]; then
-  while true; do
-      read -p "We need to erase the directory $TEST_DIR. Remove it? " yn
-      case $yn in
-          [Yy]* ) rm -Rf $TEST_DIR; break;;
-          [Nn]* ) exit;;
-          * ) echo "Please answer yes or no.";;
-      esac
-  done
-fi
-
-mkdir "$TEST_DIR"
 
 # Output the configuration file for the runner
-cat <<EOF >> $TEST_DIR/config.xml
+cat <<EOF >> "$OUTPUT_DIR/config.xml"
 <?xml version="1.0" encoding="utf-8" ?>
 <test-local-config>
 
@@ -62,7 +77,7 @@ cat <<EOF >> $TEST_DIR/config.xml
 		<test-filter></test-filter>
 		<dbtype-filter>pgsql</dbtype-filter>
     <mem-check></mem-check>
-		<temp-dir>$TEST_DIR</temp-dir>
+		<temp-dir>$OUTPUT_DIR</temp-dir>
 		<environment>
 			<variable key="GIXSQL_FIXUP_PARAMS" value="on" />
 		</environment>
@@ -96,19 +111,19 @@ cat <<EOF >> $TEST_DIR/config.xml
 		<data-source type="pgsql" index="1">
       <hostname>localhost</hostname>
       <type>pgsql</type>
-			<port>$POSTGRE_PORT</port>
-			<dbname>$POSTGRE_DB1</dbname>
-			<username>$POSTGRE_USER</username>
-			<password>$POSTGRE_PWD</password>
+			<port>$PGPORT</port>
+			<dbname>$PGDB1</dbname>
+			<username>$PGUSER</username>
+			<password>$PGPASSWORD</password>
 			<options>native_cursors=off</options>
 		</data-source>
 		<data-source type="pgsql" index="2">
       <hostname>localhost</hostname>
       <type>pgsql</type>
-			<port>$POSTGRE_PORT</port>
-			<dbname>$POSTGRE_DB2</dbname>
-			<username>$POSTGRE_USER</username>
-			<password>$POSTGRE_PWD</password>
+			<port>$PGPORT</port>
+			<dbname>$PGDB2</dbname>
+			<username>$PGUSER</username>
+			<password>$PGPASSWORD</password>
 			<options>native_cursors=off</options>
 		</data-source>
 	</data-sources>
@@ -117,9 +132,7 @@ EOF
 
 echo "Building runner..."
 # We have to rebuild the test runner because it includes test files...
-dotnet build "gixsql-tests-nunit/gixsql-tests-nunit.csproj" > /dev/null
+dotnet build "gixsql-tests-nunit/gixsql-tests-nunit.csproj"
 
 # Start the runner
 dotnet "gixsql-tests-nunit/bin/Debug/net6.0/gixsql-tests-nunit.dll"
-
-echo "Results of the tests can found in $TEST_DIR"


### PR DESCRIPTION
This commit prepares the script `run_test.sh` to be run in the CI of Superbol. Now the script configures a complete PostgreSQL database in `_output/pg` directory.

To run the script with the legacy preprocessor:
```sh
nix develop
LEGACY_PP= ./run_test.sh
```

With the new preprocessor, you need to specify the location of Superbol:
```sh
nix develop
SUPERBOL_DIR=... ./run_test.sh
```